### PR TITLE
Remove false positive PEiD Armadillo packer signatures

### DIFF
--- a/tools/yara/packer.yara
+++ b/tools/yara/packer.yara
@@ -10210,16 +10210,6 @@ condition:
 }
 	
 	
-rule Armadillov171
-{
-strings:
-		$a0 = { 55 8B EC 6A FF 68 ?? ?? ?? ?? 68 ?? ?? ?? ?? 64 A1 }
-
-condition:
-		$a0 at entrypoint
-}
-	
-	
 rule KBySV022shoooo
 {
 strings:

--- a/tools/yara/packer.yara
+++ b/tools/yara/packer.yara
@@ -14507,6 +14507,7 @@ condition:
 }
 	
 	
+/* false positive - https://www.zscaler.com/blogs/research/your-windows-8-packed
 rule Armadillov1xxv2xx
 {
 strings:
@@ -14514,7 +14515,7 @@ strings:
 
 condition:
 		$a0 at entrypoint
-}
+}*/
 	
 	
 rule HACKSTOPv111c


### PR DESCRIPTION
The Armadillov171 packer rule has false positives on PEs compiled with MSVC
https://github.com/Yara-Rules/rules/issues/39